### PR TITLE
Removed space from Link in summary

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,4 +6,4 @@
 * [Posting news](posting-news.md)
 * [Posting events](posting-events.md)
 * [Updating badgers](updating-badgers.md)
-* [Using Preview to edit images] (using-preview-to-edit-images.md)
+* [Using Preview to edit images](using-preview-to-edit-images.md)


### PR DESCRIPTION
Removed the space so that the ['Using Preview...' text displays as a link](http://webdocs.red-badger.com/)