### PR TITLE
Added black border to white image templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ This book serves as a guide to the sometimes confusing world of Prismic, Cloudin
 To get started, you need to get access to both Prismic and Cloudinary. Message any of the members on the #badger-labs team and they should be able to assist you.
 
 Each of the tasks you may wish to do are listed as chapters. Don't hesitate to contact any of the #badger-labs team for assistance! If you find any of the steps confusing, please let us know so we can make this documentation easier to follow!
+
+###Testing
+It's a good idea to test your changes locally because your copy might look right on github but not when run through gitbook. To launch gitbook locally, run the following commands and then open http://localhost:4000:
+```
+npm install
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To get started, you need to get access to both Prismic and Cloudinary. Message a
 Each of the tasks you may wish to do are listed as chapters. Don't hesitate to contact any of the #badger-labs team for assistance! If you find any of the steps confusing, please let us know so we can make this documentation easier to follow!
 
 ###Testing
-It's a good idea to test your changes locally because your copy might look right on github but not when run through gitbook. To launch gitbook locally, run the following commands and then open http://localhost:4000:
+It's a good idea to test your changes locally because your copy might look right on `github` but not when run through `gitbook`. To launch `gitbook` locally, run the following commands and then open http://localhost:4000.
 ```
 npm install
 npm run build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Documentation for Red Badger sites",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "gitbook serve" 
   },
   "repository": {
     "type": "git",

--- a/styles/website.css
+++ b/styles/website.css
@@ -1,0 +1,4 @@
+kbd {
+  display: inline-block;
+  border: solid 1px #000;  
+}

--- a/using-preview-to-edit-images.md
+++ b/using-preview-to-edit-images.md
@@ -85,7 +85,7 @@ These are sized for retina screens so may seems larger than you expect 😲 . Th
 
 1. Events page images (432px x 243px)<br>
 <kbd>
-![Events page images template](assets/edit-image-07.jpg "Meetup pages Speaker's template")
+![Events page images template](assets/edit-image-07.jpg "Events page's template")
 </kbd>
 
 2. Meetup pages Speaker images (227px x 227px) <br>

--- a/using-preview-to-edit-images.md
+++ b/using-preview-to-edit-images.md
@@ -7,7 +7,9 @@ An Image we want to use online:<br>
 ![Group of Red Badger emloyees in Krakow at night](assets/edit-image-03.png "Group of Red Badger emloyees in Krakow at night")
 
 A Template image (the correct size for a certain page or part of a page):<br>
-![Black rectangle template](assets/edit-image-14.png "Black rectangle template")
+<kbd>
+![White rectangle template](assets/edit-image-07.jpg "White rectangle template")
+</kbd>
 
 Some software (Preview):<br>
 ![Logo for Preview software](assets/edit-image-05.jpg "Logo for Preview software")


### PR DESCRIPTION
The white image templates are hard to see because they don't have a black border around them. They do on `github` because the `kbd` wrapper element is styled with a border. But this style doesn't show up on `gitbook`. So, added a custom `gitbook` style (in `styles/website.css`) to give them a black border.

Also added a build script so that changes can be tested locally without having to merge first. Running `npm run build` launches the local `gitbook` on http://localhost:4000.